### PR TITLE
Add guard_name to roles in RolesSeeder

### DIFF
--- a/App_Back_End/database/migrations/2025_06_21_000001_create_roles_permissions_table.php
+++ b/App_Back_End/database/migrations/2025_06_21_000001_create_roles_permissions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('permission_id');
+            $table->timestamps();
+
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles_permissions');
+    }
+};

--- a/App_Back_End/database/seeders/RolesSeeder.php
+++ b/App_Back_End/database/seeders/RolesSeeder.php
@@ -13,11 +13,11 @@ class RolesSeeder extends Seeder
     public function run(): void
     {
         Role::insert([
-            ['name' => 1],
-            ['name' => 2],
-            ['name' => 3],
-            ['name' => 4],
-            ['name' => 5],
+            ['name' => 1, 'guard_name' => 'web'],
+            ['name' => 2, 'guard_name' => 'web'],
+            ['name' => 3, 'guard_name' => 'web'],
+            ['name' => 4, 'guard_name' => 'web'],
+            ['name' => 5, 'guard_name' => 'web'],
         ]);
     }
 }


### PR DESCRIPTION
This pull request updates the ‎`RolesSeeder.php` file to include the ‎`guard_name` attribute for each role. Previously, roles were seeded with only a ‎`name` field; now, each role also specifies ‎`'guard_name' => 'web'`. This change ensures that roles are associated with the correct authentication guard, which is necessary for proper role-based access control in Laravel applications.